### PR TITLE
feat: 增加用户信息，默认从git配置，可修改相关方法改成从相关鉴权系统获取

### DIFF
--- a/lib/core/initClient.js
+++ b/lib/core/initClient.js
@@ -107,7 +107,7 @@ class Client {
   }
 
   initUserInfo() {
-    // 从git获取 | anywhere
+    // 从git获取 | anyotherSystem
     let args = ['config', '-l'];
     return new Promise((resolve)=>{
       const getInfo = spawn('git', args);


### PR DESCRIPTION
最底层的cli一般需处理及管理用户信息，刚使用feflow的时候有些团队或者部门还没有很完善的登录鉴权系统， 这时候如果有一个默认的user配置及相关方法的收口，可以方便用做数据统计，日志鉴权等。git信息不准确或者不满足需求可以等基建之后替换相关方法就可以完成自己的用户系统。