### PR TITLE
feat(init): support initialize project with selected generator

### DIFF
--- a/packages/feflow-cli/src/core/native/generator.ts
+++ b/packages/feflow-cli/src/core/native/generator.ts
@@ -51,11 +51,23 @@ const run = (ctx: any, name: string) => {
 
 module.exports = (ctx: any) => {
     ctx.commander.register('init', 'Create a new project', () => {
-        const { root, rootPkg } = ctx;
+        const { root, rootPkg, args } = ctx;
+        const { g, generator } = args;
+        const chooseGenerator = g || generator;
+        let chooseGeneratorIsValid = false;
+
         loadGenerator(root, rootPkg).then((generators: any) => {
             const options = generators.map((item: any) => {
+                if (item.name === chooseGenerator) {
+                    chooseGeneratorIsValid = true
+                }
                 return item.desc
             });
+
+            if(chooseGeneratorIsValid) {
+                return run(ctx, chooseGenerator); 
+            }
+
             if (generators.length) {
                 inquirer.prompt([{
                     type: 'list',

--- a/packages/feflow-cli/src/core/native/generator.ts
+++ b/packages/feflow-cli/src/core/native/generator.ts
@@ -52,19 +52,19 @@ const run = (ctx: any, name: string) => {
 module.exports = (ctx: any) => {
     ctx.commander.register('init', 'Create a new project', () => {
         const { root, rootPkg, args } = ctx;
-        const { g, generator } = args;
-        const chooseGenerator = g || generator;
-        let chooseGeneratorIsValid = false;
+        const { generator } = args;
+        const chooseGenerator = generator;
+        let isValidGenerator = false;
 
         loadGenerator(root, rootPkg).then((generators: any) => {
             const options = generators.map((item: any) => {
                 if (item.name === chooseGenerator) {
-                    chooseGeneratorIsValid = true
+                    isValidGenerator = true
                 }
                 return item.desc
             });
 
-            if(chooseGeneratorIsValid) {
+            if(isValidGenerator) {
                 return run(ctx, chooseGenerator); 
             }
 

--- a/packages/feflow-cli/types/index.d.ts
+++ b/packages/feflow-cli/types/index.d.ts
@@ -1,1 +1,2 @@
 declare module '@feflow/report';
+declare module "request-promise"


### PR DESCRIPTION
拓展init命令，允许项目初始化时提前选中脚手架
例如： `fef init -g=@feflow/generator-example`