### PR TITLE
feat: support plugin hook to pass in parameters

### DIFF
--- a/packages/feflow-cli/src/cli/index.ts
+++ b/packages/feflow-cli/src/cli/index.ts
@@ -83,11 +83,11 @@ export default function entry() {
 
     report.report(cmd, args);
 
-    feflow.hook.emit(HOOK_TYPE_BEFORE);
+    feflow.hook.emit(HOOK_TYPE_BEFORE, cmd, args);
 
     feflow.hook.on(EVENT_COMMAND_BEGIN, () => {
       return feflow.call(cmd, feflow).then(() => {
-        feflow.hook.emit(HOOK_TYPE_AFTER);
+        feflow.hook.emit(HOOK_TYPE_AFTER, cmd, args);
         logger.debug(`call ${cmd} success`);
       }).catch((err) => {
         handleError(err);

--- a/packages/feflow-cli/src/core/hook/index.ts
+++ b/packages/feflow-cli/src/core/hook/index.ts
@@ -27,19 +27,19 @@ export default class Hook {
         }
     }
 
-    emit(type: any) {
+    emit(type: any, arg?: any) {
         const args = Array.prototype.slice.call(arguments);
         args.shift();
         switch (type) {
             case HOOK_TYPE_BEFORE:
                 this.hook(HOOK_TYPE_BEFORE, () => {
-                    this.emit(EVENT_COMMAND_BEGIN);
-                });
+                    this.emit(EVENT_COMMAND_BEGIN, ...args);
+                }, args);
                 break;
             case HOOK_TYPE_AFTER:
                 this.hook(HOOK_TYPE_AFTER, () => {
-                    this.emit(EVENT_DONE);
-                });
+                    this.emit(EVENT_DONE, ...args);
+                }, args);
                 break;
             default:
                 const listeners = this.listeners[type];
@@ -60,7 +60,7 @@ export default class Hook {
      * @param {string} type
      * @param {Function} fn
      */
-    hook(type: any, fn: any) {
+    hook(type: any, fn: any, args?: any) {
         const hooks = this.listeners[type];
 
         const next = (i: any) => {
@@ -69,7 +69,7 @@ export default class Hook {
                 return fn();
             }
 
-            const result = hook.call();
+            const result = hook(...args);
             if (result && typeof result.then === 'function') {
                 result.then(
                     () => {


### PR DESCRIPTION
support plugin hook to pass in parameters
`feflow.hook.on('before', async(cmd, args) => {`
`console.log(cmd, args);`
`})`
`$ fef add 1 2`
`$ add { _: [ 1, 2 ] }`