### PR TITLE
fix: HOOK_TYPE_AFTER will never called

### DIFF
--- a/packages/feflow-cli/src/core/index.ts
+++ b/packages/feflow-cli/src/core/index.ts
@@ -319,6 +319,7 @@ export default class Feflow {
             const cmd = this.commander.get(name);
             if (cmd) {
                 cmd.call(this, ctx);
+                resolve()
             } else {
                 reject(new Error('Command `' + name + '` has not been registered yet!'));
             }


### PR DESCRIPTION
feflow.call没有调用resolve，HOOK_TYPE_AFTER不会被执行
https://github.com/Tencent/feflow/blob/master/packages/feflow-cli/src/cli/index.ts#L90 