### PR TITLE
fix: fix feflow warn color too light in item2 light mode issue#263

### DIFF
--- a/packages/feflow-cli/src/core/logger/index.ts
+++ b/packages/feflow-cli/src/core/logger/index.ts
@@ -38,7 +38,7 @@ const levelColors: IObject = {
   10: 'gray',
   20: 'gray',
   30: 'green',
-  40: 'yellow',
+  40: 'orange',
   50: 'red',
   60: 'red'
 };


### PR DESCRIPTION
修改 feflow warn 颜色 yellow => orange，经测试，orange 在浅色模式下对眼睛的效果比 yellow 更好