### PR TITLE
feat: add more help usage

### DIFF
--- a/packages/feflow-cli/package.json
+++ b/packages/feflow-cli/package.json
@@ -38,7 +38,6 @@
     "@types/command-line-usage": "^5.0.1",
     "@types/cross-spawn": "^6.0.0",
     "@types/easy-table": "0.0.32",
-    "@types/execa": "^2.0.0",
     "@types/figlet": "^1.2.0",
     "@types/inquirer": "^6.0.3",
     "@types/js-yaml": "^3.12.1",
@@ -61,7 +60,6 @@
   "dependencies": {
     "@feflow/feflow-plugin-devtool": "0.0.1",
     "@feflow/report": "^0.2.0",
-    "@types/execa": "^2.0.0",
     "abbrev": "^1.1.1",
     "axios": "^0.19.2",
     "bunyan": "^1.8.12",
@@ -70,7 +68,6 @@
     "commander": "^2.20.0",
     "cross-spawn": "^6.0.5",
     "easy-table": "^1.1.1",
-    "execa": "^4.0.1",
     "figlet": "^1.2.3",
     "import-fresh": "^3.1.0",
     "inquire": "^0.4.8",

--- a/packages/feflow-cli/src/core/index.ts
+++ b/packages/feflow-cli/src/core/index.ts
@@ -80,7 +80,7 @@ export default class Feflow {
   }
 
   async init(cmd: string) {
-    this.reporter.init(cmd);
+    this.reporter.init && this.reporter.init(cmd);
     if (cmd === 'config') {
       await this.initClient();
       await this.loadNative();

--- a/packages/feflow-cli/src/core/native/help.ts
+++ b/packages/feflow-cli/src/core/native/help.ts
@@ -1,4 +1,9 @@
 import commandLineUsage from 'command-line-usage';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import spawn from 'cross-spawn';
+import { UNIVERSAL_README_CONFIG } from '../../shared/constant';
 
 const getCommands = (store: any) => {
   const arr = [];
@@ -12,7 +17,7 @@ const getCommands = (store: any) => {
   return arr;
 };
 
-const showHelp = (commands: Array<Object>) => {
+const showHelp = (commands: Array<Record<string, any>>) => {
   const sections = [
     {
       header: 'Usage',
@@ -54,10 +59,98 @@ const showHelp = (commands: Array<Object>) => {
   return usage;
 };
 
+const parseReadme = (path: any) => {
+  let readmeText;
+  if (fs.existsSync(path)) {
+    try {
+      readmeText = fs.readFileSync(path, 'utf8');
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+  return readmeText;
+};
+
 module.exports = (ctx: any) => {
   ctx.commander.register('help', 'Help messages', () => {
+    const { store } = ctx.commander;
+    let cmd = ctx.args['_'][0];
+    cmd = cmd && String.prototype.toLowerCase.call(cmd);
+
+    // fef help xxx 的 case
+    if (cmd) {
+      if (Object.prototype.hasOwnProperty.call(store, cmd)) {
+        const commandInfo = store[cmd];
+
+        // 优先展示组件注册信息
+        if (commandInfo.options && commandInfo.options.length) {
+          const { type, content } = commandInfo.options[0];
+
+          // case 1: 多语言情况下 yml 有 usage 属性时，执行对应的内容
+          if (type === 'usage') {
+            spawn(content, {
+              stdio: 'inherit',
+              shell: true
+            });
+            return;
+          }
+
+          // case 2: 多语言情况下 yml 没有 usage 属性时，优先读取 readme 展示出来
+          if (type === 'path') {
+            const pluginConfigPath = path.join(
+              content,
+              UNIVERSAL_README_CONFIG
+            );
+            const readmeText = parseReadme(pluginConfigPath);
+
+            if (readmeText) {
+              console.log(
+                chalk.yellow(
+                  `No usage was found in command '${cmd}'. Below is the README.md`
+                )
+              );
+              console.log(readmeText);
+              return;
+            }
+
+            // case 3: 多语言情况下既没有 usage，又没有 README.md，则展示插件的 desc
+            console.log(
+              chalk.yellow(
+                `No usage was found in command '${cmd}'. Below is the description.`
+              )
+            );
+            console.log(commandInfo.desc);
+            return;
+          }
+
+          // case 4: nodejs 且有写 options 的情况
+          const usage = commandLineUsage(commandInfo.options);
+          console.log(usage);
+          return;
+        }
+
+        // case 5: nodejs 且没有写 options 的情况，直接展示插件的 desc
+        console.log(
+          chalk.yellow(
+            `No usage was found in command '${cmd}'. Below is the description.`
+          )
+        );
+        console.log(commandInfo.desc);
+        return;
+      }
+
+      console.log(
+        chalk.yellow(
+          `Command '${cmd}' not found in feflow. You need to install it first.`
+        )
+      );
+      console.log(`Below is the usage of feflow.`);
+    }
+
+    // 打印 fef 的 usage
     const commands = getCommands(ctx.commander.store);
     const usage = showHelp(commands);
     console.log(usage);
+    return;
   });
 };

--- a/packages/feflow-cli/src/core/plugin/loadUniversalPlugin.ts
+++ b/packages/feflow-cli/src/core/plugin/loadUniversalPlugin.ts
@@ -45,6 +45,13 @@ function register(ctx: any, pkg: string, version: string, global = false) {
   if (global) {
     const universalPkg: UniversalPkg = ctx.universalPkg;
     const pluginDescriptions = plugin.desc || `${pkg} universal plugin description`;
+    const usage = plugin.usage ? {
+      type: "usage",
+      content: plugin.usage
+    } : {
+      type: "path",
+      content: plugin.path
+    };
     commander.register(pluginCommand, pluginDescriptions, async () => {
       await updateUniversalPlugin(ctx, pkg, version, plugin);
       const newVersion = universalPkg.getInstalled().get(pkg);
@@ -54,7 +61,7 @@ function register(ctx: any, pkg: string, version: string, global = false) {
       } 
       plugin = loadPlugin(ctx, pkg, newVersion);
       await execPlugin(ctx, pkg, newVersion, plugin);
-    }, [], pkg);
+    }, [usage], pkg);
   } else {
     commander.registerInvisible(`${pluginCommand}@${version}`, async () => {
       await execPlugin(ctx, pkg, version, plugin);

--- a/packages/feflow-cli/src/core/universal-pkg/schema/plugin.ts
+++ b/packages/feflow-cli/src/core/universal-pkg/schema/plugin.ts
@@ -5,7 +5,7 @@ import { platform } from './base';
 export class Plugin {
   private ctx: any;
 
-  private path: string;
+  path: string;
 
   desc: string;
 
@@ -28,6 +28,8 @@ export class Plugin {
   preUpgrade: Command;
 
   postUpgrade: Command;
+
+  usage: any;
 
   constructor(ctx: any, pluginPath: string, config: any) {
     if (!platform) {
@@ -54,6 +56,7 @@ export class Plugin {
       this.path,
       config?.['post-upgrade']
     );
+    this.usage = config?.['usage'];
   }
 
   async check() {

--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -53,3 +53,5 @@ export const UNIVERSAL_PKG_JSON = 'universal-package.json';
 export const UNIVERSAL_PLUGIN_CONFIG = 'plugin.yml';
 
 export const NPM_PLUGIN_INFO_JSON = 'npm-plugin-info.json';
+
+export const UNIVERSAL_README_CONFIG = 'README.md';


### PR DESCRIPTION
支持 fef help xxx 来展示 xxx 插件 usage 的场景。
如果是多语言开发插件，依次是：
1、执行  yml 配置的 usage 命令
2、有 readme 情况下展示 readme
3、其他情况展示 desc
如果是 node，则是
1、有 options 展示 options
2、没有则展示 desc
如果命令未注册，添加一个提示的 console 然后展示 fef 的 usage
如果 xxx 参数为空，直接展示 fef 的 usage