### PR TITLE
feat: add global link to register command when install plugin with -g option

### DIFF
--- a/packages/feflow-cli/src/core/commander/index.ts
+++ b/packages/feflow-cli/src/core/commander/index.ts
@@ -4,11 +4,13 @@ export default class Commander {
   private store: any;
   private invisibleStore: any;
   private alias: any;
+  private onRegistered?: Function;
 
-  constructor() {
+  constructor(onRegistered?: Function) {
     this.store = {};
     this.invisibleStore = {};
     this.alias = {};
+    if (typeof onRegistered === 'function') this.onRegistered = onRegistered;
   }
 
   get(name: any) {
@@ -29,11 +31,15 @@ export default class Commander {
   }
 
   register(name: string, desc: string, fn: Function, options?: Array<object>, pluginName?: string) {
-    this.store[name.toLowerCase()] = fn;
+    const storeKey = name.toLowerCase();
+    this.store[storeKey] = fn;
     this.store[name.toLowerCase()].desc = desc;
     this.store[name.toLowerCase()].options = options;
     this.store[name.toLowerCase()].pluginName = pluginName;
     this.alias = abbrev(Object.keys(this.store));
+    if (this.onRegistered) {
+      this.onRegistered(storeKey);
+    }
   }
 
   registerInvisible(name: string, fn: Function, options?: Array<object>, pluginName?: string) {

--- a/packages/feflow-cli/src/core/hook/index.ts
+++ b/packages/feflow-cli/src/core/hook/index.ts
@@ -27,9 +27,7 @@ export default class Hook {
     }
   }
 
-  emit(type: any) {
-    const args = Array.prototype.slice.call(arguments);
-    args.shift();
+  emit(type: any, ...args: []) {
     switch (type) {
       case HOOK_TYPE_BEFORE:
         this.hook(HOOK_TYPE_BEFORE, () => {

--- a/packages/feflow-cli/src/core/index.ts
+++ b/packages/feflow-cli/src/core/index.ts
@@ -17,7 +17,8 @@ import {
   FEFLOW_BIN,
   FEFLOW_LIB,
   UNIVERSAL_PKG_JSON,
-  UNIVERSAL_MODULES
+  UNIVERSAL_MODULES,
+  HOOK_TYPE_ON_COMMAND_REGISTERED
 } from '../shared/constant';
 import { safeDump, parseYaml } from '../shared/yaml';
 import packageJson from '../shared/packageJson';
@@ -65,8 +66,10 @@ export default class Feflow {
     this.version = pkg.version;
     this.config = parseYaml(configPath);
     this.configPath = configPath;
-    this.commander = new Commander();
     this.hook = new Hook();
+    this.commander = new Commander((cmdName: string) => {
+      this.hook.emit(HOOK_TYPE_ON_COMMAND_REGISTERED, cmdName);
+    });
     this.logger = logger({
       debug: Boolean(args.debug),
       silent: Boolean(args.silent)

--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -34,6 +34,8 @@ export const HOOK_TYPE_BEFORE = 'before';
  */
 export const HOOK_TYPE_AFTER = 'after';
 
+export const HOOK_TYPE_ON_COMMAND_REGISTERED = 'on_command_registered';
+
 /**
  * Emitted when command execution begins
  */

--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -51,3 +51,5 @@ export const UNIVERSAL_MODULES = 'universal_modules';
 export const UNIVERSAL_PKG_JSON = 'universal-package.json';
 
 export const UNIVERSAL_PLUGIN_CONFIG = 'plugin.yml';
+
+export const NPM_PLUGIN_INFO_JSON = 'npm-plugin-info.json';


### PR DESCRIPTION
此 pr 包含两方面内容：

1. 修复 hook emit 方法参数丢失
2. 修改 fef install/uninstall 方法，当 fef install 有 -g 参数时， 将注册的命令注册到系统全局，具体流程如下
![image](https://user-images.githubusercontent.com/6998403/86221497-91ef2680-bbb7-11ea-95d7-fcdae6f12812.png)
