### PR TITLE
fix: failed to check terminal when file does not exist

### DIFF
--- a/packages/feflow-cli/src/core/universal-pkg/binp/index.ts
+++ b/packages/feflow-cli/src/core/universal-pkg/binp/index.ts
@@ -90,6 +90,9 @@ export default class Binp {
       console.warn(`unknown terminal, please add ${binPath} to the path`);
       return;
     }
+    if (!fs.existsSync(profile)) {
+      return profile;
+    }
     const content = fs.readFileSync(profile)?.toString();
     if (content?.indexOf(setStatement) === -1) {
       return profile;


### PR DESCRIPTION
修复类似下面的问题（早期修复过一版但场景有遗漏）

![image](https://user-images.githubusercontent.com/21966767/88768897-4d52ad00-d1ae-11ea-9790-d3bfcc120c2e.png)
