### PR TITLE
feat: 引入 cli-markdown 来支持 terminal 中 markdown 语法

### DIFF
--- a/packages/feflow-cli/package.json
+++ b/packages/feflow-cli/package.json
@@ -65,6 +65,7 @@
     "axios": "^0.19.2",
     "bunyan": "^1.8.12",
     "chalk": "^2.4.2",
+    "cli-markdown": "^1.7.0",
     "command-line-usage": "^6.1.0",
     "commander": "^2.20.0",
     "cross-spawn": "^6.0.5",

--- a/packages/feflow-cli/src/core/native/help.ts
+++ b/packages/feflow-cli/src/core/native/help.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import spawn from 'cross-spawn';
+import cliMd from 'cli-markdown';
 import { UNIVERSAL_README_CONFIG } from '../../shared/constant';
 
 const getCommands = (store: any) => {
@@ -68,7 +69,7 @@ const parseReadme = (path: any) => {
       throw new Error(e);
     }
   }
-  return readmeText;
+  return cliMd(readmeText);
 };
 
 module.exports = (ctx: any) => {

--- a/packages/feflow-cli/types/index.d.ts
+++ b/packages/feflow-cli/types/index.d.ts
@@ -1,2 +1,3 @@
 declare module '@feflow/report';
 declare module 'request-promise';
+declare module 'cli-markdown';


### PR DESCRIPTION
引入 cli-markdown 来支持 terminal 中 markdown 语法
![image](https://user-images.githubusercontent.com/9033585/88792235-7e8ea580-d1cd-11ea-8a7e-3dc4b5d99275.png)
