### PR TITLE
隐藏日志上报

### DIFF
--- a/packages/feflow-cli/src/core/logger/index.ts
+++ b/packages/feflow-cli/src/core/logger/index.ts
@@ -1,14 +1,14 @@
 import bunyan from 'bunyan';
 import chalk from 'chalk';
 import { Writable } from 'stream';
-import loggerReport from './report';
+// import loggerReport from './report';
 
 const pkg = require('../../../package.json');
 const PLUGE_NAME = 'feflow-' + pkg.name.split('/').pop();
 const process = require('process');
-var timer:any;
+// var timer:any;
 let logger:any;
-const report = new loggerReport();
+// const report = new loggerReport();
 interface IObject {
   [key: string]: string;
 }
@@ -50,13 +50,13 @@ const levelColors: IObject = {
   60: 'red'
 };
 
-var loggerArr:Array<Object> = [];
+// var loggerArr:Array<Object> = [];
 
-process.on('SIGINT',async ()=>{
-  await report.init(loggerArr);
-  // 操作中断
-  process.exit();
-});
+// process.on('SIGINT',async ()=>{
+//   await report.init(loggerArr);
+//   // 操作中断
+//   process.exit();
+// });
 class ConsoleStream extends Writable {
   private debug: Boolean;
 
@@ -81,24 +81,24 @@ class ConsoleStream extends Writable {
       const err = data.err.stack || data.err.message;
       if (err) msg += chalk.yellow(err) + '\n';
     }
-    //每次触发logger进行存储 大于20条上报
-    await report.init([{
-      level: level,
-      msg: `[Feflow ${levelNames[level]}][${loggerName}]${data.msg}`,
-      date: new Date().getTime(),
-      name:loggerName
-    }]);
+    // //每次触发logger进行存储 大于20条上报
+    // await report.init([{
+    //   level: level,
+    //   msg: `[Feflow ${levelNames[level]}][${loggerName}]${data.msg}`,
+    //   date: new Date().getTime(),
+    //   name:loggerName
+    // }]);
 
     if (level >= 40) {
       process.stderr.write(msg);
     } else {
       process.stdout.write(msg);
     }
-    clearTimeout(timer);
-    //单次logger上报间隔大于5s时自动进行一次上报
-    timer = setTimeout(async ()=>{
-      await report.init([],true);
-    },5000)
+    // clearTimeout(timer);
+    // //单次logger上报间隔大于5s时自动进行一次上报
+    // timer = setTimeout(async ()=>{
+    //   await report.init([],true);
+    // },5000)
     callback();
   }
 }

--- a/packages/feflow-cli/src/core/native/install.ts
+++ b/packages/feflow-cli/src/core/native/install.ts
@@ -30,6 +30,7 @@ import versionImpl from '../universal-pkg/dep/version';
 import InstallPersistence, { InstallAttribute } from '../universal-pkg/persistence/install';
 import applyPlugins from '../plugin/applyPlugins';
 import { CommandPickConfig  } from "../command-picker";
+// import loggerReport from '../logger/report';
 
 let installP: InstallPersistence;
 let account: any;


### PR DESCRIPTION
日志上报能力目前存在比较严重的并发问题，影响可用性。

另外性能上也存在不足，建议重新设计后再上线，这个提交屏蔽了日志上报的能力

日志上报问题重现方式：
1. 安装feflow-plugin-epc，由于耗时长，打印日志多，并发问题极容易出现（导致日志丢失或自身抛异常）
2. 运行任何指令，只要打印一条日志，就需要5s才会结束进程（日志最长5s或满20条上报的策略没问题，但实现上导致了这个问题）
3. 每写一条日志，触发上报时就会有读文件、写文件等一连串操作，对耗时影响较大