### PR TITLE
fix: 添加更新子进程错误兼容检测和用户提示

### DIFF
--- a/packages/feflow-cli/src/core/resident/error.ts
+++ b/packages/feflow-cli/src/core/resident/error.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import osenv from 'osenv';
+import { FEFLOW_ROOT, RESIDENT_ERROR_LOG } from '../../shared/constant';
+
+const root = path.join(osenv.home(), FEFLOW_ROOT);
+const defaultErrorLogFile = path.join(root, RESIDENT_ERROR_LOG);
+
+export default class ErrorInstance {
+  private jsonFile: string;
+
+  constructor(errorJsonFile: string = defaultErrorLogFile) {
+    this.jsonFile = errorJsonFile;
+    if (!fs.existsSync(errorJsonFile)) {
+      fs.appendFileSync(errorJsonFile, '{}', 'utf-8');
+    }
+  }
+
+  read(scope: string, key?: string | undefined): string | object | undefined {
+    try {
+      const fileBuffer = fs.readFileSync(this.jsonFile);
+      const errorJson = JSON.parse(fileBuffer.toString());
+      if (Object.prototype.hasOwnProperty.call(errorJson, scope)) {
+        if (key) {
+          if (Object.prototype.hasOwnProperty.call(errorJson[scope], key)) {
+            return errorJson[scope][key];
+          }
+          return;
+        } else {
+          return errorJson[scope];
+        }
+      }
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  update(scope: string, key: string | undefined, value: any): undefined {
+    try {
+      let modified = false;
+      const fileBuffer = fs.readFileSync(this.jsonFile);
+      const errorJson = JSON.parse(fileBuffer.toString());
+      if (!errorJson[scope]) {
+        modified = true;
+        errorJson[scope] = {};
+      }
+      if (key) {
+        // key 值不重复写，不覆盖
+        if (Object.prototype.hasOwnProperty.call(errorJson[scope], key)) {
+          return;
+        }
+        modified = true;
+        errorJson[scope][key] = value;
+      } else {
+        modified = true;
+        errorJson[scope] = value;
+      }
+      modified &&
+        fs.writeFileSync(
+          this.jsonFile,
+          JSON.stringify(errorJson, null, 4),
+          'utf-8'
+        );
+    } catch (e) {
+      throw e;
+    }
+  }
+}

--- a/packages/feflow-cli/src/core/resident/index.ts
+++ b/packages/feflow-cli/src/core/resident/index.ts
@@ -13,6 +13,7 @@ import {
   CHECK_UPDATE_GAP
 } from '../../shared/constant';
 import { safeDump } from '../../shared/yaml';
+import ErrorInstance from './error';
 
 const updateBeatProcess = path.join(__dirname, './updateBeat');
 const updateProcess = path.join(__dirname, './update');
@@ -22,6 +23,7 @@ let db: DBInstance;
 let heartDB: DBInstance;
 const table = new Table();
 const uTable = new Table();
+const errorStack = new ErrorInstance();
 
 function startUpdateBeat(ctx: any) {
   const child = spawn(process.argv[0], [updateBeatProcess], {
@@ -122,10 +124,28 @@ async function _checkUpdateMsg(ctx: any, updateData: any = {}) {
     }
   };
 
+  const _showErrorM = (scope: string) => {
+    const errorMsg = errorStack.read(scope) || {};
+    const keys = Object.keys(errorMsg);
+
+    if (keys.length) {
+      ctx.logger.warn('Some problems occurred while auto-updating');
+      keys.forEach(key => {
+        ctx.logger.error(`${key}: ${errorMsg[key]}`);
+      });
+      ctx.logger.warn(
+        'These templates or plugins need to be updated manually util problems fixed'
+      );
+      errorStack.update(scope, undefined, {});
+    }
+  };
+
   // cli -> tnpm -> universal
   _showCliUpdateM();
   _showPluginsUpdateM();
   _showUniversalPluginsM();
+  _showErrorM('update');
+  _showErrorM('exception');
 
   await db.update('update_data', updateData);
 }

--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -82,3 +82,5 @@ export const FEFLOW_PLUGIN_GIT_PREFIX = 'feflow-plugin-git-';
 export const FEFLOW_PLUGIN_PREFIX = 'feflow-plugin-';
 
 export const LOG_FILE = 'logger.log';
+
+export const RESIDENT_ERROR_LOG = 'resident-error.json';


### PR DESCRIPTION
1、兼容 getPkgInfo 方法可能直接 throw 错误的 case，还能继续检测接下来的多语言插件
2、添加组件 errorStack 用于跨进程通知错误信息，在用户下次命令执行即告知用户
3、catch update 和 updateBeat 方法中可能出现的错误，并在用户下次执行命令的时候告知用户
![image](https://user-images.githubusercontent.com/9033585/105036045-e516c100-5a96-11eb-841f-d3fbbab98d05.png)
