### PR TITLE
fix(picker): cache uses node version to distinguish

### DIFF
--- a/packages/feflow-cli/src/core/command-picker/index.ts
+++ b/packages/feflow-cli/src/core/command-picker/index.ts
@@ -421,8 +421,8 @@ export default class CommandPicker {
   }
 
   isAvailable() {
-    const tartgetCommand = this.cacheController.getCommandPath(this.cmd);
-    const { type } = tartgetCommand || {};
+    const tartgetCommand = this.cacheController.getCommandPath(this.cmd) || {};
+    const { type } = tartgetCommand;
 
     if (type === COMMAND_TYPE.UNIVERSAL_PLUGIN_TYPE) {
       const { version, pkg } = tartgetCommand as TargetUniversalPlugin;

--- a/packages/feflow-cli/src/core/command-picker/index.ts
+++ b/packages/feflow-cli/src/core/command-picker/index.ts
@@ -109,7 +109,7 @@ export class CommandPickConfig {
     this.root = path.join(osenv.home(), FEFLOW_ROOT);
     // cache uses node version to distinguish
     const nodeVersion = process.version;
-    const cacheFileFolder = path.join(this.root, `cache_${nodeVersion}`);
+    const cacheFileFolder = path.join(this.root, `cache`, nodeVersion);
     if (!fs.existsSync(cacheFileFolder)) {
       fs.mkdirSync(cacheFileFolder, { recursive: true });
     }

--- a/packages/feflow-cli/src/core/native/help.ts
+++ b/packages/feflow-cli/src/core/native/help.ts
@@ -10,10 +10,10 @@ import { UNIVERSAL_README_CONFIG } from '../../shared/constant';
 const getCommands = (store: any) => {
   const arr = [];
   for (const name in store) {
-    const desc = store[name].desc;
+    const desc = store[name].desc || '';
     arr.push({
       colA: name,
-      colB: desc instanceof Function ? desc() : desc
+      colB: (desc instanceof Function ? desc() : desc).replace(/({|})/g, (val: string) => escape(val))
     });
   }
   return arr;

--- a/packages/feflow-cli/src/core/native/list.ts
+++ b/packages/feflow-cli/src/core/native/list.ts
@@ -157,10 +157,8 @@ module.exports = (ctx: any) => {
         const localPath = item.name
           .replace(FEFLOW_PLUGIN_LOCAL_PREFIX, '')
           .replace(/::/g, path.sep);
-        showPlugin(ctx, localPath,item);
+        showPlugin(ctx, localPath, item);
       });
     }
   });
 };
-
-

--- a/packages/feflow-cli/src/core/native/logger.ts
+++ b/packages/feflow-cli/src/core/native/logger.ts
@@ -1,17 +1,16 @@
-
-module.exports = (ctx:any) => {
-    ctx.commander.register('logger', 'logger Message', () => {
-      const args = ctx.args._ || [];
-      const [types,msg] = args;
-      switch (types){
-         case 'info':
-         case 'warn':
-         case 'error':
-            ctx.logger[types](msg);
-            break;
-         default:
-             console.log('nothing types');
-            break;
-      }
-    });
-  };
+module.exports = (ctx: any) => {
+  ctx.commander.register('logger', 'logger Message', () => {
+    const args = ctx.args._ || [];
+    const [types, msg] = args;
+    switch (types) {
+      case 'info':
+      case 'warn':
+      case 'error':
+        ctx.logger[types](msg);
+        break;
+      default:
+        console.log('nothing types');
+        break;
+    }
+  });
+};

--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -59,7 +59,7 @@ export const NPM_PLUGIN_INFO_JSON = 'npm-plugin-info.json';
 
 export const UNIVERSAL_README_CONFIG = 'README.md';
 
-export const CACHE_FILE = ".feflowCache.yml";
+export const CACHE_FILE = '.feflowCache.yml';
 
 export const HEART_BEAT_COLLECTION = 'heart-beat.db';
 

--- a/packages/feflow-cli/src/shared/fefError.ts
+++ b/packages/feflow-cli/src/shared/fefError.ts
@@ -47,7 +47,8 @@ export class FefError {
   }
 
   printError(obj: PrintError) {
-    let { pluginPath } = obj;
+    const { pluginPath } = obj;
+
     if (!pluginPath) {
       if (!this.checkPick()) {
         this.context.logger.debug('无法找到命令路径');
@@ -95,17 +96,16 @@ export class FefError {
     if (type === COMMAND_TYPE.PLUGIN_TYPE) {
       configPath = join(pluginPath, this.pluginFile);
     } else if (type === COMMAND_TYPE.UNIVERSAL_PLUGIN_TYPE) {
-      this.unversalpluginFile.forEach((ext) => {
-        let tmpPath = join(pluginPath as string, ext);
+      this.unversalpluginFile.forEach(ext => {
+        const tmpPath = join(pluginPath as string, ext);
         if (existsSync(tmpPath)) configPath = tmpPath;
       });
     } else if (type === COMMAND_TYPE.NATIVE_TYPE) {
       return this.defaultDocs;
     }
-
     if (existsSync(configPath)) {
       const config = this.parseConfig(configPath);
-      this.docsPathList.forEach((docsPath) => {
+      this.docsPathList.forEach(docsPath => {
         if (docs) return;
         docs = get(config, docsPath);
       });

--- a/packages/feflow-cli/src/shared/yaml.ts
+++ b/packages/feflow-cli/src/shared/yaml.ts
@@ -28,6 +28,5 @@ export function safeDump(obj: object, path: any) {
   } catch (e) {
     throw new Error(e);
   }
-
   return fs.writeFileSync(path, doc, 'utf-8');
 }


### PR DESCRIPTION
用户如果有多个node版本，那么在不同版本使用feflow会使用到相同的命令缓存配置，对于原始命令就会出现错误调用，对原始命令需要做node版本区分