### PR TITLE
fix: show no such remote

### DIFF
--- a/packages/feflow-report/src/common/utils.ts
+++ b/packages/feflow-report/src/common/utils.ts
@@ -17,6 +17,7 @@ const exec = (command: string) => {
   try {
     result = execSync(command, {
       windowsHide: true,
+      stdio: 'pipe',
     })
       .toString()
       .replace(/\n/, '');


### PR DESCRIPTION
此次提交修复了 Feflow 在非 Git 仓库路径下执行时，会因为 Git 的错误输出打印 "No Such Remote" 的问题