### PR TITLE
feat: 多语言插件支持beta版本

### DIFF
--- a/packages/feflow-cli/src/core/universal-pkg/dep/version.ts
+++ b/packages/feflow-cli/src/core/universal-pkg/dep/version.ts
@@ -17,7 +17,7 @@ class SemverVersion implements Version {
     if (version === this.latestVersion) {
       return true;
     }
-    return /^v(0|[1-9]\d*).(0|[1-9]\d*).(0|[1-9]\d*)$/i.test(version);
+    return !!semver.valid(version);
   }
 
   valid(version: string): string {

--- a/packages/feflow-cli/src/core/universal-pkg/repository/git.ts
+++ b/packages/feflow-cli/src/core/universal-pkg/repository/git.ts
@@ -25,22 +25,17 @@ export async function getTag(repoUrl: string, version?: string): Promise<string 
 
   const tagList = tagListStr.split('\n');
   let satisfiedMaxVersion: string | undefined;
-  for (const tagStr of tagList) {
+  tagList.forEach((tagStr: string) => {
     const [, tagReference] = tagStr.split('\t');
     const tag = tagReference?.substring('refs/tags/'.length);
-    if (!versionImpl.check(tag)) {
-      continue;
-    }
     if (tag === version) {
       return tag;
     }
-    if (version && !versionImpl.satisfies(tag, version)) {
-      continue;
-    }
-    if (!satisfiedMaxVersion || versionImpl.gt(tag, satisfiedMaxVersion)) {
+    if (tag.includes(version || '') && (!satisfiedMaxVersion || versionImpl.gt(tag, satisfiedMaxVersion))) {
       satisfiedMaxVersion = tag;
     }
-  }
+  });
+
   return satisfiedMaxVersion;
 }
 


### PR DESCRIPTION
cli、npm包、多语言插件发 beta/alpha 版本的标准：
1、由于项目中使用 semver.gt 来判断版本更新，因此根据其规则：如果当前线上版本为 a.b.c，那么 beta/alpha 需要是 a.b.c-betaxxx 或者 a.b.c-alphaxxx
2、可以发布比 a.b.c 低的 beta/alpha 版本，但是不允许发布比 a.b.c 更高的版本，防止自动更新默认更新到了