### PR TITLE
fix: 修复 file read timeout 问题

### DIFF
--- a/packages/feflow-cli/src/shared/constant.ts
+++ b/packages/feflow-cli/src/shared/constant.ts
@@ -90,3 +90,6 @@ export const UPDATE_LOCK = 'update.lock';
 export const SILENT_ARG = '--slient';
 
 export const DISABLE_ARG = '--disable-check';
+
+// 心跳进程名字
+export const FEFLOW_UPDATE_BEAT_PROCESS  = 'feflow-update-beat-process';

--- a/packages/feflow-cli/src/shared/process.ts
+++ b/packages/feflow-cli/src/shared/process.ts
@@ -1,0 +1,87 @@
+// 查询进程的代码参考https://github.com/neekey/ps
+import { spawn } from 'child_process';
+import os from 'os';
+
+/**
+ * End of line.
+ * Basically, the EOL should be:
+ * - windows: \r\n
+ * - *nix: \n
+ * try to get every possibilities covered.
+ */
+const EOL = /(\r\n)|(\n\r)|\n|\r/;
+const SystemEOL = os.EOL;
+const IS_WIN = process.platform === 'win32';
+
+function lookUpAllProcess(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (IS_WIN) {
+      const CMD = spawn('cmd');
+      let stdout = '';
+      let stderr = '';
+
+      CMD.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      CMD.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      CMD.on('exit', () => {
+        let beginRow: any;
+        const stdoutArr = stdout.split(EOL);
+
+        // Find the line index for the titles
+        stdoutArr.forEach((out: string | string[], index: any) => {
+          if (out && typeof beginRow === 'undefined' && out.indexOf('CommandLine') === 0) {
+            beginRow = index;
+          }
+        });
+
+        // get rid of the start (copyright) and the end (current pwd)
+        stdoutArr.splice(stdout.length - 1, 1);
+        stdoutArr.splice(0, beginRow);
+
+        if (stderr) {
+          return reject(stderr);
+        }
+        return resolve(stdoutArr.join(SystemEOL));
+      });
+
+      CMD.stdin.write('wmic process get ProcessId,ParentProcessId,CommandLine \n');
+      CMD.stdin.end();
+    } else {
+      const child = spawn('ps', ['aux']);
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('exit', () => {
+        if (stderr) {
+          return reject(stderr);
+        }
+        return resolve(stdout);
+      });
+    }
+  });
+};
+
+// 判断某个进程是否存在
+export async function isProcessExist(psName: string) {
+  let psInfo: string;
+  try {
+    psInfo = await lookUpAllProcess();
+    const pattern = new RegExp(`${psName}`);
+    return pattern.test(psInfo);
+  } catch (e) {
+    console.error(e);
+  }
+};


### PR DESCRIPTION
fix: 修复 file read time out 问题

初始化时检测心跳进程如果不存在并且心跳和更新文件时上锁状态时解锁 packages/feflow-cli/src/core/resident/index.ts
心跳进程退出时如果心跳和更新文件时上锁状态解锁 packages/feflow-cli/src/core/resident/update-beat.ts
检测进程是否存在函数 packages/feflow-cli/src/shared/process.ts

-story=20220715