### PR TITLE
Remove david-dm from README

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -10,7 +10,6 @@
 
 [![npm][npm]][npm-url]
 [![Build Status][build-status]][build-status-url]
-[![deps][deps]][deps-url]
 [![Install Size][size]][size-url]
 [![Downloads][downloads]][downloads-url]
 [![lerna][lerna]][lerna-url]
@@ -60,8 +59,6 @@ npm install @feflow/cli -g
 [build-status-url]: https://travis-ci.org/Tencent/feflow
 [contributors]: https://img.shields.io/github/contributors/Tencent/feflow.svg
 [contributors-url]: https://github.com/Tencent/feflow/graphs/contributors
-[deps]: https://img.shields.io/david/Tencent/feflow.svg
-[deps-url]: https://david-dm.org/Tencent/feflow
 [downloads]: https://img.shields.io/npm/dw/@feflow/cli.svg
 [downloads-url]: https://www.npmjs.com/package/@feflow/cli
 [issue-resolution]: https://isitmaintained.com/badge/resolution/Tencent/feflow.svg

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Every release, along with the migration instructions, is documented on the GitHu
 [build-status-url]: https://travis-ci.org/Tencent/feflow
 [contributors]: https://img.shields.io/github/contributors/Tencent/feflow.svg
 [contributors-url]: https://github.com/Tencent/feflow/graphs/contributors
-[deps]: https://img.shields.io/david/Tencent/feflow.svg
-[deps-url]: https://david-dm.org/Tencent/feflow
 [downloads]: https://img.shields.io/npm/dw/@feflow/cli.svg
 [downloads-url]: https://www.npmjs.com/package/@feflow/cli
 [issue-resolution]: https://isitmaintained.com/badge/resolution/Tencent/feflow.svg


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.