### PR TITLE
fix(@feflow/cli): 修复开发套件命令注册错误

### DIFF
--- a/packages/feflow-cli/src/core/devkit/load-devkits.ts
+++ b/packages/feflow-cli/src/core/devkit/load-devkits.ts
@@ -12,7 +12,7 @@ interface CommandConfig {
 
 const registerDevkitCommand = (command: string, commandConfig: CommandConfig, directoryPath: string, ctx: Feflow) => {
   const { builder, options: builderOptions } = commandConfig;
-  const [packageName] = builder.split(':', 2);
+  const [packageName, devkitCmd] = builder.split(':', 2);
   const config = new Config(ctx);
   const pkgPath = path.join(directoryPath, 'node_modules', packageName);
   try {
@@ -21,7 +21,7 @@ const registerDevkitCommand = (command: string, commandConfig: CommandConfig, di
       ctx.logger.debug('devkit config not found!');
       return;
     }
-    const { implementation, description, optionsDescription, usage = {} } = devkitConfig.builders[command];
+    const { implementation, description, optionsDescription, usage = {} } = devkitConfig.builders[devkitCmd];
 
     const options = getCommandLine(optionsDescription || usage, description, command);
     const devkitLogger = logger({
@@ -57,7 +57,7 @@ const registerDevkitCommand = (command: string, commandConfig: CommandConfig, di
       );
     }
   } catch (e) {
-    ctx.logger.debug(`${pkgPath} not found!`);
+    ctx.logger.debug(e, 'register devkit command failed');
   }
 };
 


### PR DESCRIPTION
用户使用 `.feflowrc` 注册项目命令时，例如：
```json
{
  "projectCmd": {
    "builder" : "feflow-devkit-demo:devkitCmd"
  }
}
```
应读取 `feflow-devkit-demo` 下
`devkit.json` 中 `devkitCmd` 对应的配置，而不是 `projectCmd` 的