### PR TITLE
fix(@feflow/cli): 修复终端配置文件中 feflow bin 路径被注释时的误判

### DIFF
--- a/packages/feflow-cli/src/core/universal-pkg/binp/index.ts
+++ b/packages/feflow-cli/src/core/universal-pkg/binp/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import spawn from 'cross-spawn';
 import osenv from 'osenv';
+import escapeRegExp from 'lodash/escapeRegExp';
 
 /**
  * register the directory to the environment variable path
@@ -101,8 +102,10 @@ export default class Binp {
     if (!fs.existsSync(profile)) {
       return profile;
     }
-    const content = fs.readFileSync(profile)?.toString();
-    if (content?.indexOf(setStatement) === -1) {
+    const content = fs.readFileSync(profile)?.toString() || '';
+    // 排除包含字符串但被注释的情况
+    const setStatementRegExp = new RegExp(`(?<!#.*)${escapeRegExp(setStatement)}`);
+    if (!setStatementRegExp.test(content)) {
       return profile;
     }
     this.handleUnsupportedTerminal(profile);


### PR DESCRIPTION
被注释的 export feflow bin path 命令应判断为无效，并重新添加